### PR TITLE
Fix `+/-` rendering

### DIFF
--- a/u64/user_interface.rst
+++ b/u64/user_interface.rst
@@ -65,7 +65,7 @@ keyboard is slightly different:
 | CRSR up/down                      | Move the cursor (highlighted      |
 |                                   | line) up/down                     |
 +-----------------------------------+-----------------------------------+
-| + / -                             | Increase or decrease a setting,   |
+| `+` / `-`                         | Increase or decrease a setting,   |
 |                                   | cycling through the available     |
 |                                   | options.                          |
 +-----------------------------------+-----------------------------------+


### PR DESCRIPTION
Escape `+` and `-` to fix documentation rendering on https://1541u-documentation.readthedocs.io/en/latest/quick_guide.html